### PR TITLE
Set icon theme before creating the QApplication

### DIFF
--- a/0001-force-Breeze-icon-theme.patch
+++ b/0001-force-Breeze-icon-theme.patch
@@ -1,25 +1,13 @@
-From c5e692d56ad926593a2b138b4ace9f173f8bfd4c Mon Sep 17 00:00:00 2001
-From: Matthieu Gallien <matthieu_gallien@yahoo.fr>
-Date: Mon, 2 Jul 2018 17:33:51 +0200
-Subject: [PATCH 1/2] force Breeze icon theme
-
----
- src/main.cpp | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/src/main.cpp b/src/main.cpp
-index aacd94d..14660c2 100644
+index f6ff16e4..d5f1a473 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -102,6 +102,8 @@ int main(int argc, char *argv[])
+@@ -79,6 +79,8 @@ int main(int argc, char *argv[])
  
-     KLocalizedString::setApplicationDomain("elisa");
+     qputenv("QT_GSTREAMER_USE_PLAYBIN_VOLUME", "true");
  
 +    QIcon::setThemeName(QStringLiteral("breeze"));
 +
-     QCommandLineParser parser;
-     parser.addHelpOption();
-     parser.addVersionOption();
--- 
-2.19.0
-
+     QApplication app(argc, argv);
+ 
+ #if defined KF5Declarative_FOUND && KF5Declarative_FOUND


### PR DESCRIPTION
On Plasma if the icon theme is not breeze, then Elisa has no icons.

### Currently
![elisa-before](https://user-images.githubusercontent.com/50304471/116439109-dab75080-a857-11eb-9949-5fa71e08b8f8.png)

### With this patch
![elisa-after](https://user-images.githubusercontent.com/50304471/116439113-dbe87d80-a857-11eb-97be-7898e6fd887f.png)
