### PR TITLE
Pull LMDB from GitLab, not GitHub

### DIFF
--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -62,13 +62,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_0.9.29.tar.gz",
-                    "sha256": "22054926b426c66d8f2bc22071365df6e35f3aacf19ad943bc6167d4cae3bebb",
+                    "url": "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz",
+                    "sha256": "d4c668167a2d703ef91db733b4069b8b74dbc374405855be6626b45e2a7e2dd3",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 6974,
                         "stable-only": true,
-                        "url-template": "https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_$version.tar.gz"
+                        "url-template": "https://git.openldap.org/openldap/openldap/-/archive/LMDB_$version/openldap-LMDB_$version.tar.gz"
                     }
                 }
             ],


### PR DESCRIPTION
The GitHub URL is just a mirror can be out of sync with the original sources at GitLab. This can happen on the day of a new release, which happened today.